### PR TITLE
feat: Only validate upon download

### DIFF
--- a/src/main/java/no/difi/move/deploymanager/action/application/PrepareApplicationAction.java
+++ b/src/main/java/no/difi/move/deploymanager/action/application/PrepareApplicationAction.java
@@ -31,6 +31,7 @@ public class PrepareApplicationAction implements ApplicationAction {
             log.info("Latest version is different from current, and will be downloaded");
             try {
                 doDownload(application, downloadJarFile);
+                application.setMarkedForValidation(true);
             } catch (Exception ex) {
                 throw new DeployActionException("Error occurred when downloading latest version", ex);
             }

--- a/src/main/java/no/difi/move/deploymanager/action/application/ValidateAction.java
+++ b/src/main/java/no/difi/move/deploymanager/action/application/ValidateAction.java
@@ -29,7 +29,11 @@ public class ValidateAction implements ApplicationAction {
 
     @Override
     public Application apply(Application application) {
-        log.info("Validating jar");
+        if (!application.isMarkedForValidation()){
+            log.info("Skipping validation, as no new distribution has been downloaded");
+            return application;
+        }
+        log.info("Validating application");
         log.trace("Calling ValidateAction.apply on application {}", application);
         try {
             assertChecksumIsCorrect(application, ALGORITHM.SHA1);
@@ -39,7 +43,6 @@ public class ValidateAction implements ApplicationAction {
             if (verify) {
                 log.trace("Signature has been successfully verified.");
             }
-
             return application;
         } catch (Exception ex) {
             throw new DeployActionException("Error validating jar", ex);

--- a/src/main/java/no/difi/move/deploymanager/domain/application/Application.java
+++ b/src/main/java/no/difi/move/deploymanager/domain/application/Application.java
@@ -9,6 +9,7 @@ public class Application {
     private ApplicationMetadata latest;
     private ApplicationMetadata current;
     private LaunchResult launchResult;
+    private boolean markedForValidation;
 
     public boolean isSameVersion() {
         return latest.getVersion().equals(current.getVersion());

--- a/src/test/java/no/difi/move/deploymanager/action/application/PrepareApplicationActionTest.java
+++ b/src/test/java/no/difi/move/deploymanager/action/application/PrepareApplicationActionTest.java
@@ -82,11 +82,13 @@ public class PrepareApplicationActionTest {
     @Test
     public void apply_NewVersionFound_ShouldDownload() {
         given(fileMock.exists()).willReturn(false);
-        assertThat(target.apply(application)).isSameAs(application);
 
+        final Application result = target.apply(application);
+
+        assertThat(result.isMarkedForValidation()).isTrue();
+        assertThat(result).isSameAs(application);
         File resultFile = application.getLatest().getFile();
         assertThat(resultFile).isSameAs(fileMock);
-
         verify(nexusRepoMock).downloadJAR(eq(NEW_APPLICATION_VERSION), same(pathMock));
     }
 
@@ -109,7 +111,7 @@ public class PrepareApplicationActionTest {
         given(deployDirectoryRepoMock.getBlacklistPath(any())).willReturn(blackListedFileMock);
         given(blackListedFileMock.getAbsolutePath()).willReturn("/tmp/test.jar.blacklisted");
 
-        assertThatCode(()->target.apply(application)).doesNotThrowAnyException();
+        assertThatCode(() -> target.apply(application)).doesNotThrowAnyException();
     }
 
     @Test
@@ -126,7 +128,7 @@ public class PrepareApplicationActionTest {
     }
 
     @Test
-    public void apply_NewVersionIsNotFound_ShouldNotDownload() {
+    public void apply_NoNewVersionIsDownloaded_ShouldNotDownload() {
         given(fileMock.exists()).willReturn(true);
         assertThat(target.apply(application)).isSameAs(application);
 

--- a/src/test/java/no/difi/move/deploymanager/action/application/ValidateActionTest.java
+++ b/src/test/java/no/difi/move/deploymanager/action/application/ValidateActionTest.java
@@ -25,15 +25,12 @@ import java.io.FileInputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
@@ -71,6 +68,7 @@ public class ValidateActionTest {
                 .setVersion("version")
                 .setFile(fileMock)
         );
+        application.setMarkedForValidation(true);
 
         signature = "signature";
         given(fileMock.getAbsolutePath()).willReturn("jarPath");
@@ -124,5 +122,15 @@ public class ValidateActionTest {
                 .isInstanceOf(DeployActionException.class)
                 .hasCause(new DeployActionException(null));
         verify(gpgService).verify("jarPath", "tull");
+    }
+
+    @Test
+    public void apply_NoNewDistributionHasBeenDownloaded_ShouldNotValidate() {
+        application.setMarkedForValidation(false);
+
+        target.apply(application);
+
+        verify(nexusRepoMock,never()).downloadSignature(anyString());
+        verify(gpgService, never()).verify(anyString(), anyString());
     }
 }


### PR DESCRIPTION
Adds boolean field to Application POJO that toggles verification
(checksum and signature) in ValidateAction only when a new distribution
has been downloaded. Need to verify that new SNAPSHOT versions are not
skipped in the current version.